### PR TITLE
Fix typo

### DIFF
--- a/src/main/resources/trades.yml
+++ b/src/main/resources/trades.yml
@@ -3,7 +3,7 @@ example_trade:
     - FARMER
   output:
     type: SLIMEFUN
-    id: ZIN_INGOT
+    id: ZINC_INGOT
     amount: 32
   input:
     1:


### PR DESCRIPTION
## Description
There is a typo in the example trade, and it makes it so when first trying the plugin nothing loads XD

## Proposed changes
Fix the typo

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
